### PR TITLE
Fix app startup broken by stale imports after mcda consolidation

### DIFF
--- a/src/relife_technical/app.py
+++ b/src/relife_technical/app.py
@@ -3,7 +3,7 @@ from importlib.metadata import version
 from fastapi import FastAPI
 
 from relife_technical.config.logging import configure_logging
-from relife_technical.routes import auth, examples, health, ee, rei, sei, uc, fv
+from relife_technical.routes import auth, examples, health, mcda
 
 # Dynamically determine the package name
 package_name = __name__.split(".")[0]
@@ -27,10 +27,4 @@ app = FastAPI(
 app.include_router(health.router)
 app.include_router(auth.router)
 app.include_router(examples.router)
-
-#Technical service endpoints
-app.include_router(ee.router)
-app.include_router(rei.router)
-app.include_router(sei.router)
-app.include_router(uc.router)
-app.include_router(fv.router)
+app.include_router(mcda.router)

--- a/src/relife_technical/config/logging.py
+++ b/src/relife_technical/config/logging.py
@@ -83,6 +83,12 @@ class RichStructuredLogger:
         formatted_msg = self._format_message(msg, "debug", **kwargs)
         self._logger.debug(formatted_msg)
 
+    def exception(self, msg: str, **kwargs: Any) -> None:
+        """Log an error message with traceback and optional structured data."""
+
+        formatted_msg = self._format_message(msg, "error", **kwargs)
+        self._logger.exception(formatted_msg)
+
 
 def get_logger(name: str) -> RichStructuredLogger:
     """Get a logger instance with Rich-compatible structured logging methods.

--- a/src/relife_technical/routes/mcda.py
+++ b/src/relife_technical/routes/mcda.py
@@ -1,18 +1,17 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from relife_financial.auth.dependencies import OptionalAuthenticatedUserDep
-from relife_service_template.config.logging import get_logger
-from relife_service_template.models.mcda import (
+from fastapi import APIRouter, HTTPException, status
+from relife_technical.auth.dependencies import OptionalAuthenticatedUserDep
+from relife_technical.config.logging import get_logger
+from relife_technical.models.mcda import (
     McdaTopsisRequest,
     McdaTopsisResponse,
     RankedTechnology,
 )
-from relife_service_template.services.mcda_topsis import topsis_rank_technologies
-from relife_financial.config.settings import SettingsDep
+from relife_technical.services.mcda_topsis import topsis_rank_technologies
 
 router = APIRouter(tags=["mcda"], prefix="/mcda")
 logger = get_logger(__name__)
 
-@router.post("/mcda/topsis", response_model=McdaTopsisResponse)
+@router.post("/topsis", response_model=McdaTopsisResponse)
 async def run_topsis(
     payload: McdaTopsisRequest,
     current_user: OptionalAuthenticatedUserDep,
@@ -22,7 +21,7 @@ async def run_topsis(
 
         logger.info(
             "Running TOPSIS ranking",
-            user_id=current_user.user_id,
+            user_id=current_user.user_id if current_user else None,
             profile=payload.profile,
             n_technologies=len(technologies),
         )

--- a/tests/test_mcda.py
+++ b/tests/test_mcda.py
@@ -1,0 +1,61 @@
+from fastapi.testclient import TestClient
+
+from relife_technical.app import app
+
+client = TestClient(app)
+
+_ALL_KPI_KEYS = [
+    "envelope_kpi",
+    "window_kpi",
+    "heating_system_kpi",
+    "cooling_system_kpi",
+    "ii_kpi",
+    "aoc_kpi",
+    "irr_kpi",
+    "npv_kpi",
+    "pp_kpi",
+    "arv_kpi",
+    "st_coverage_kpi",
+    "onsite_res_kpi",
+    "net_energy_export_kpi",
+    "embodied_carbon_kpi",
+    "gwp_kpi",
+    "thermal_comfort_air_temp_kpi",
+    "thermal_comfort_humidity_kpi",
+]
+
+_MINIMAL_TECHNOLOGY = {"name": "TechA", **{k: 50.0 for k in _ALL_KPI_KEYS}}
+_MINS_MAXES = {k: [0.0, 100.0] for k in _ALL_KPI_KEYS}
+
+
+def test_mcda_router_registered():
+    """The mcda router must appear in the OpenAPI schema."""
+
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+
+    paths = response.json().get("paths", {})
+
+    assert any(
+        "/mcda" in path for path in paths
+    ), "No /mcda path found in OpenAPI schema — mcda router is not registered"
+
+
+def test_mcda_topsis_returns_ranking():
+    """A valid TOPSIS request returns a ranked list of technologies."""
+
+    payload = {
+        "profile": "Environment-Oriented",
+        "technologies": [_MINIMAL_TECHNOLOGY],
+        "mins_maxes": _MINS_MAXES,
+    }
+
+    response = client.post("/mcda/topsis", json=payload)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["profile"] == "Environment-Oriented"
+    assert data["count"] == 1
+    assert len(data["ranking"]) == 1
+    assert data["ranking"][0]["name"] == "TechA"
+    assert "closeness" in data["ranking"][0]


### PR DESCRIPTION
## Summary

- After commit 8b73bb3 consolidated five separate route modules into a single `mcda` module, `app.py` was not updated: it still imported and registered the deleted modules (`ee`, `rei`, `sei`, `uc`, `fv`), making the service fail to start with `ImportError`.
- `routes/mcda.py` was created with copy-paste errors that prevented the endpoint from working even after correcting `app.py`.